### PR TITLE
Region name must be set explicitly.

### DIFF
--- a/examples/2. Subscribing to data.ipynb
+++ b/examples/2. Subscribing to data.ipynb
@@ -105,7 +105,7 @@
    "outputs": [],
    "source": [
     "import boto3\n",
-    "sqs = boto3.client('sqs')"
+    "sqs = boto3.client('sqs', region_name='eu-west-2')"
    ]
   },
   {


### PR DESCRIPTION
region_name could also be set in the user's boto3 config file.  But, for beginners, it might be best to set it explicitly when calling `boto3.client()`

(Great work on the tutorials, BTW!)